### PR TITLE
yktoken: remove encoding.binary's Read()/Write()

### DIFF
--- a/yk_test.go
+++ b/yk_test.go
@@ -285,11 +285,7 @@ func TestParse(t *testing.T) {
 			continue
 		}
 
-		buf, err := res.Bytes()
-		if err != nil {
-			t.Errorf("TestParse test #%d failed: %v", x, err)
-			continue
-		}
+		buf := res.Bytes()
 
 		if !bytes.Equal(buf, test.result) {
 			t.Errorf("TestParse test #%d failed: got: %x want: %x",
@@ -307,21 +303,15 @@ func TestOtp(t *testing.T) {
 			continue
 		}
 		key := NewKey(string(test.key))
-		otp, err := token.Generate(key)
-		if err != nil {
-			t.Errorf("TestOtp test #%d failed: %v", x, err)
-			continue
-		}
+		otp := token.Generate(key)
+
 		res, err := otp.Parse(key)
 		if err != nil {
 			t.Errorf("TestOtp test #%d failed: %v", x, err)
 			continue
 		}
-		buf, err := res.Bytes()
-		if err != nil {
-			t.Errorf("TestOtp test #%d failed: %v", x, err)
-			continue
-		}
+		buf := res.Bytes()
+
 		if !bytes.Equal(test.token, buf) {
 			t.Errorf("TestOtp test #%d failed: got: %v want: %v",
 				x, test.token, buf)


### PR DESCRIPTION
Using reflection is slow and we know what's inside a token.  Just call
the read and write bits we need.  In my benchmarking, this moves from
~2000ns/op to about 40ns/op.

This patch ends up touching more code because by removing error the
Read() and Write() calls, a number of routines no longer have error
codes to return and so this patch recursively removes those up the stack
as well.
